### PR TITLE
Enable to add an album url to a live

### DIFF
--- a/app/controllers/lives_controller.rb
+++ b/app/controllers/lives_controller.rb
@@ -13,6 +13,7 @@ class LivesController < ApplicationController
 
   def new
     @live = Live.new
+    @live.date = Date.today
   end
 
   def edit

--- a/app/controllers/lives_controller.rb
+++ b/app/controllers/lives_controller.rb
@@ -70,6 +70,6 @@ class LivesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def live_params
-    params.require(:live).permit(:name, :date, :place)
+    params.require(:live).permit(:name, :date, :place, :album_url)
   end
 end

--- a/app/models/live.rb
+++ b/app/models/live.rb
@@ -3,6 +3,7 @@ class Live < ApplicationRecord
   scope :order_by_date, -> { order(date: :desc) }
   validates :name, presence: true, uniqueness: { scope: :date }
   validates :date, presence: true
+  validates :album_url, format: /\A#{URI.regexp(%w[http https])}\z/, allow_blank: true
 
   def self.years
     Live.order_by_date.select(:date).map(&:nendo).uniq

--- a/app/views/lives/_form.html.haml
+++ b/app/views/lives/_form.html.haml
@@ -16,4 +16,9 @@
     .col-sm-9
       = f.text_field :place, class: 'form-control', placeholder: '4共21'
 
+  .form-group
+    = f.label :album_url, class: 'col-sm-3 control-label'
+    .col-sm-9
+      = f.text_field :album_url, class: 'form-control', placeholder: 'https://goo.gl/photos/o94hbpFHQtcjzjwj6'
+
   = render 'shared/submit', f: f

--- a/app/views/lives/_form.html.haml
+++ b/app/views/lives/_form.html.haml
@@ -9,7 +9,7 @@
   .form-group
     = f.label :date, class: 'col-sm-3 control-label'
     .col-sm-9
-      = f.date_field :date, value: Date.today, class: 'form-control'
+      = f.date_field :date, class: 'form-control'
 
   .form-group
     = f.label :place, class: 'col-sm-3 control-label'

--- a/app/views/lives/show.html.haml
+++ b/app/views/lives/show.html.haml
@@ -11,7 +11,9 @@
 
     %h1<
       = @live.name
-      %small= "#{I18n.l(@live.date)} @#{@live.place}"
+      %small
+        = " #{I18n.l(@live.date)} @#{@live.place}"
+        = link_to glyphicon(:picture), @live.album_url, target: '_blank'
 
   - if @live.songs.count > 20
     .table-responsive

--- a/db/migrate/20170812075755_add_album_url_to_lives.rb
+++ b/db/migrate/20170812075755_add_album_url_to_lives.rb
@@ -1,0 +1,5 @@
+class AddAlbumUrlToLives < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lives, :album_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170811131258) do
+ActiveRecord::Schema.define(version: 20170812075755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20170811131258) do
     t.string   "place"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "album_url"
     t.index ["date"], name: "index_lives_on_date", using: :btree
     t.index ["name", "date"], name: "index_lives_on_name_and_date", unique: true, using: :btree
   end

--- a/spec/factories/lives.rb
+++ b/spec/factories/lives.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     name 'テストライブ'
     sequence(:date) { |n| Date.new(2000) + n.month }
     place '4共21'
+    album_url 'https://goo.gl/photos/o94hbpFHQtcjzjwj6'
   end
 end

--- a/spec/models/live_spec.rb
+++ b/spec/models/live_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Live, type: :model do
   it { is_expected.to respond_to(:date) }
   it { is_expected.to respond_to(:place) }
   it { is_expected.to respond_to(:songs) }
+  it { is_expected.to respond_to(:album_url) }
 
   it { is_expected.to be_valid }
 
@@ -34,6 +35,11 @@ RSpec.describe Live, type: :model do
     it 'should raise an exception when live is deleted with songs' do
       expect { live.destroy }.to raise_exception ActiveRecord::DeleteRestrictionError
     end
+  end
+
+  describe 'when album_url is not URL' do
+    before { live.album_url = 'invalid url' }
+    it { is_expected.not_to be_valid }
   end
 end
 


### PR DESCRIPTION
This resolves #56 

- `lives` テーブルに `album_url` カラムを追加しました
- `album_url` の編集・表示できるようにしました