### PR TITLE
Add a uniqueness validation to Playing model

### DIFF
--- a/app/models/playing.rb
+++ b/app/models/playing.rb
@@ -4,7 +4,7 @@ class Playing < ApplicationRecord
 
   before_save :format_inst
 
-  validates :user_id, presence: true
+  validates :user_id, presence: true, uniqueness: { scope: :song_id }
   validates :song, presence: true
 
   scope :count_insts, -> { group(:inst).count(:id) }

--- a/spec/models/playing_spec.rb
+++ b/spec/models/playing_spec.rb
@@ -22,4 +22,9 @@ RSpec.describe Playing, type: :model do
     before { playing.song_id = nil }
     it { is_expected.not_to be_valid }
   end
+
+  describe 'when the combination of user and song is already taken' do
+    before { playing.dup.save }
+    it { is_expected.not_to be_valid }
+  end
 end


### PR DESCRIPTION
Relates to #27 

### 問題

1つの曲にメンバーを重複して登録しようとすると `PG::UniqueViolation: ERROR: duplicate key value violates unique constraint` で落ちる

### 解決方法

`Playing` モデルに適切な validation を追加した