### PR TITLE
Fix Regular Meeting model

### DIFF
--- a/app/models/regular_meeting.rb
+++ b/app/models/regular_meeting.rb
@@ -28,7 +28,7 @@ class RegularMeeting
       return REGULAR_MEETINGS_INFO_URL + url
     end
   rescue => e
-    logger.error e.message
+    Rails.logger.error e.message
     nil
   end
 
@@ -37,7 +37,7 @@ class RegularMeeting
     match = doc.at_css('#mahoimain').to_s.match(/\n#{date.day}（[月火水木金土日]）(?<place>[@×][^（<\n]*)(?:（(?<note>.+)）)?.*<br>/)
     [match[:place], match[:note]]
   rescue => e
-    logger.error e.message
+    Rails.logger.error e.message
     nil
   end
 end

--- a/app/models/regular_meeting.rb
+++ b/app/models/regular_meeting.rb
@@ -3,7 +3,7 @@
 require 'open-uri'
 
 class RegularMeeting
-  REGULAR_MEETINGS_INFO_URL = 'http://s.maho.jp/homepage/7cffb2d25ef87ff8/'
+  REGULAR_MEETINGS_INFO_URL = URI.parse('https://s.maho.jp/homepage/7cffb2d25ef87ff8/')
 
   attr_reader :date, :place, :note, :place_url
 
@@ -17,16 +17,9 @@ class RegularMeeting
 
   def fetch_detail_url
     doc = Nokogiri::HTML(open(REGULAR_MEETINGS_INFO_URL))
-    url = doc.css("a:contains('#{date.month}月活動予定')").attribute('href').value
-    if url.start_with?('http')
-      return url
-    elsif url.start_with?('//')
-      return 'https:' + url
-    elsif url.start_with?('/')
-      return 'http://s.hamo.jp' + url
-    else
-      return REGULAR_MEETINGS_INFO_URL + url
-    end
+    url = URI.parse(doc.css("a:contains('#{date.month}月活動予定')").attribute('href').value)
+    url = REGULAR_MEETINGS_INFO_URL.merge(url) unless url.absolute?
+    url.to_s
   rescue => e
     Rails.logger.error e.message
     nil

--- a/app/models/regular_meeting.rb
+++ b/app/models/regular_meeting.rb
@@ -17,7 +17,16 @@ class RegularMeeting
 
   def fetch_detail_url
     doc = Nokogiri::HTML(open(REGULAR_MEETINGS_INFO_URL))
-    doc.css("a:contains('#{date.month}月活動予定')").attribute('href').value
+    url = doc.css("a:contains('#{date.month}月活動予定')").attribute('href').value
+    if url.start_with?('http')
+      return url
+    elsif url.start_with?('//')
+      return 'https:' + url
+    elsif url.start_with?('/')
+      return 'http://s.hamo.jp' + url
+    else
+      return REGULAR_MEETINGS_INFO_URL + url
+    end
   rescue => e
     logger.error e.message
     nil


### PR DESCRIPTION
- correspond to various forms of urls
- fix logging code

changes: app/models/regular_meeting.rb

例会教室お知らせページが, SSLに対応し始めた関係で, 月ごとの例会教室ページへのリンクが, プロトコル省略のURLに変更されました (自動生成されているので, お知らせページ側での修正は難しそうです). 将来の変更を見こし, urlが ルート相対パス, プロトコル省略, 相対パスの場合に対応させました.