### PR TITLE
Update .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Style/ClassAndModuleChildren:
 
 Style/Documentation:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Metrics/LineLength:
   Max: 120
 
 Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
+  Enabled: false
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
Disabled followings:

- `Style/ClassAndModuleChildren`
- `Style/FrozenStringLiteralComment`