### PR TITLE
Add entry list pages and make draft live pages redirect to them

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -3,6 +3,10 @@ class EntriesController < ApplicationController
   before_action :set_live
   before_action :draft_live
 
+  def index
+    #
+  end
+
   def new
     @song = @live.songs.build
     @song.playings.build

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -4,7 +4,7 @@ class EntriesController < ApplicationController
   before_action :draft_live
 
   def index
-    #
+    @entries = @live.songs.played_order.includes(playings: :user).select { |song| song.editable?(current_user) }
   end
 
   def new

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -20,7 +20,7 @@ class EntriesController < ApplicationController
     else
       flash[:danger] = 'メールの送信に失敗しました'
     end
-    redirect_to @song.live
+    redirect_to action: :index
   rescue ActiveRecord::RecordNotUnique
     @song.add_error_for_duplicated_user
   end

--- a/app/controllers/lives_controller.rb
+++ b/app/controllers/lives_controller.rb
@@ -1,11 +1,11 @@
 class LivesController < ApplicationController
   before_action :set_live, only: %i[show edit update destroy]
   before_action :logged_in_user, except: %i[index show]
-  before_action :logged_in_user, only: :show, if: :draft_live?
   before_action :admin_or_elder_user, except: %i[index show]
+  before_action :performed_live, only: :show
 
   def index
-    @lives = logged_in? ? Live.order_by_date : Live.performed.order_by_date
+    @lives = Live.performed.order_by_date
   end
 
   def show
@@ -56,8 +56,8 @@ class LivesController < ApplicationController
     @live = Live.includes(:songs).find(params[:id])
   end
 
-  def draft_live?
-    @live.draft?
+  def performed_live
+    redirect_to live_entries_url(@live) if @live.draft?
   end
 
   def live_params

--- a/app/models/live.rb
+++ b/app/models/live.rb
@@ -7,7 +7,7 @@ class Live < ApplicationRecord
 
   scope :order_by_date, -> { order(date: :desc) }
   scope :nendo, ->(year) { where(date: Date.new(year, 4, 1)...Date.new(year + 1, 4, 1)) }
-  scope :draft, -> { where('date > ?', Time.zone.today) }
+  scope :drafts, -> { where('date > ?', Time.zone.today) }
   scope :performed, -> { where('date <= ?', Time.zone.today) }
 
   def self.years

--- a/app/views/entries/_form.html.haml
+++ b/app/views/entries/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: @song, url: live_entry_path, class: 'form-horizontal well') do |f|
+= form_with(model: @song, url: live_entries_path, class: 'form-horizontal well') do |f|
 
   .form-group
     = f.label :name, class: 'col-sm-3 control-label'

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -1,1 +1,9 @@
 - provide(:title, @live.title)
+%header.page-header
+  %h1<
+    = @live.name
+    %small
+      = " #{I18n.l(@live.date)} @#{@live.place} "
+
+- if @entries.present?
+  = render 'lives/songs_table', songs: @entries

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -1,0 +1,1 @@
+- provide(:title, @live.title)

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -7,3 +7,7 @@
 
 - if @entries.present?
   = render 'lives/songs_table', songs: @entries
+
+.row
+  %p.col-sm-offset-3.col-sm-6
+    = link_to glyphicon(:send) + 'エントリーする', new_live_entry_path(@live), class: 'btn btn-primary btn-lg btn-block'

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -23,6 +23,14 @@
               %ul.dropdown-menu
                 %li= link_to 'New Live', new_live_path
                 %li= link_to 'New Member', new_user_path
+          - if Live.drafts.exists?
+            %li.dropdown
+              %a{href: '#', class: 'dropdown-toggle', 'data-toggle': 'dropdown', role: 'button', 'aria-haspopup': 'true', 'aria-expanded': 'false'}
+                Entry
+                %span.caret
+              %ul.dropdown-menu
+                - Live.drafts.each do |live|
+                  %li= link_to live.name, live_entries_path(live)
           %li.dropdown
             %a{href: '#', class: 'dropdown-toggle', 'data-toggle': 'dropdown', role: 'button', 'aria-haspopup': 'true', 'aria-expanded': 'false'}
               = current_user.full_name
@@ -31,11 +39,6 @@
               %li= link_to glyphicon(:user) + 'Profile',  current_user
               %li= link_to glyphicon(:cog) + 'Settings', edit_user_path(current_user)
               %li= link_to glyphicon('log-out') + 'Log out', logout_path, method: :delete
-              - if Live.draft.exists?
-                %li.divider{role: 'separator'}
-                %li.dropdown-header Entry
-                - Live.draft.each do |live|
-                  %li= link_to live.name, new_live_entry_path(live)
               %li.divider{role: 'separator'}
               %li= link_to glyphicon(:comment) + 'Report', feedback_url(current_user), target: '_blank'
       - else

--- a/app/views/lives/_songs_table.html.haml
+++ b/app/views/lives/_songs_table.html.haml
@@ -1,0 +1,20 @@
+.table-responsive
+  %table#songs.table.table-striped.table-condensed
+    %thead
+      %tr
+        %th #
+        %th Song
+        %th Artist
+        %th Members
+        %th
+    %tbody
+      - songs.each do |song|
+        - cache_unless logged_in?, song do
+          %tr
+            %td= song.time_order
+            %td= song.watchable?(current_user) ? link_to(song.name, song) : song.name
+            %td= song.artist
+            %td
+              %ul.list-inline
+                = render sort_by_inst(song.playings)
+            %td= render 'songs/link_to_edit', song: song

--- a/app/views/lives/show.html.haml
+++ b/app/views/lives/show.html.haml
@@ -22,26 +22,7 @@
   - songs = @live.songs.played_order.includes(playings: :user)
   - songs = songs.select { |song| song.editable?(current_user) } if @live.draft?
   - if @live.nf?
-    .table-responsive
-      %table#songs.table.table-striped.table-condensed
-        %thead
-          %tr
-            %th #
-            %th Song
-            %th Artist
-            %th Members
-            %th
-        %tbody
-          - songs.each do |song|
-            - cache_unless logged_in?, song do
-              %tr
-                %td= song.time_order
-                %td= song.watchable?(current_user) ? link_to(song.name, song) : song.name
-                %td= song.artist
-                %td
-                  %ul.list-inline
-                    = render sort_by_inst(song.playings)
-                %td= render 'songs/link_to_edit', song: song
+    = render 'songs_table', songs: songs
   - else
     %ol#set-list
       - songs.each do |song|

--- a/app/views/lives/show.html.haml
+++ b/app/views/lives/show.html.haml
@@ -7,8 +7,6 @@
         = " #{I18n.l(@live.date)} @#{@live.place} "
       - if logged_in?
         %ul.list-inline.pull-right
-          - if @live.draft?
-            %li= link_to glyphicon(:send) + '曲を出す', new_live_entry_path(@live), class: 'btn btn-info btn-lg'
           - if @live.album_url.present?
             %li= link_to glyphicon(:picture) + 'アルバム', @live.album_url, class: 'btn btn-primary btn-lg', target: '_blank', 'data-toggle': 'tooltip', 'data-placement': 'top', title: '持っている写真を共有しよう！'
 
@@ -19,13 +17,11 @@
       - unless @live.songs.exists?
         %li= link_to glyphicon(:trash) + 'Delete', @live, method: :delete, class: 'btn btn-danger', role: 'button'
 
-  - songs = @live.songs.played_order.includes(playings: :user)
-  - songs = songs.select { |song| song.editable?(current_user) } if @live.draft?
   - if @live.nf?
-    = render 'songs_table', songs: songs
+    = render 'songs_table', songs: @live.songs.played_order.includes(playings: :user)
   - else
     %ol#set-list
-      - songs.each do |song|
+      - @live.songs.played_order.includes(playings: :user).each do |song|
         - cache_unless logged_in?, song do
           %li
             = song.watchable?(current_user) ? link_to(song.name, song) : song.name
@@ -33,4 +29,3 @@
             = render 'songs/link_to_edit', song: song
             %ul.list-inline
               = render sort_by_inst(song.playings)
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :songs
 
   resources :lives do
-    resource :entry, only: %i[new create]
+    resources :entries, only: %i[index new create]
   end
 
   resources :users, path: :members do

--- a/spec/features/entry_pages_spec.rb
+++ b/spec/features/entry_pages_spec.rb
@@ -1,16 +1,22 @@
 require 'rails_helper'
 
 RSpec.feature 'EntryPages', type: :feature do
-  given(:live) { create(:live, date: Time.zone.today + 1.month) }
+  given(:live) { create(:draft_live) }
 
   feature 'Show the entry list for the live' do
     given(:user) { create(:user) }
-
-    scenario 'A logged-in user can visit the entry list' do
+    given!(:their_entry) { create(:draft_song, live: live, name: 'Visible song', user: user) }
+    given!(:other_entry) { create(:draft_song, live: live, name: 'Invisible song') }
+    background do
       log_in_as user
+    end
+
+    scenario 'A logged-in user can see the entries only they will play' do
       visit live_entries_path(live)
 
       expect(page).to have_title(live.title)
+      expect(page).to have_content('Visible song')
+      expect(page).not_to have_content('Invisible song')
     end
   end
 

--- a/spec/features/entry_pages_spec.rb
+++ b/spec/features/entry_pages_spec.rb
@@ -12,7 +12,8 @@ RSpec.feature 'EntryPages', type: :feature do
     end
 
     scenario 'A logged-in user can see the entries only they will play' do
-      visit live_entries_path(live)
+      visit root_path
+      click_link live.name
 
       expect(page).to have_title(live.title)
       expect(page).to have_link('エントリーする', href: new_live_entry_path(live))

--- a/spec/features/entry_pages_spec.rb
+++ b/spec/features/entry_pages_spec.rb
@@ -3,7 +3,18 @@ require 'rails_helper'
 RSpec.feature 'EntryPages', type: :feature do
   given(:live) { create(:live, date: Time.zone.today + 1.month) }
 
-  feature 'Entry' do
+  feature 'Show the entry list for the live' do
+    given(:user) { create(:user) }
+
+    scenario 'A logged-in user can visit the entry list' do
+      log_in_as user
+      visit live_entries_path(live)
+
+      expect(page).to have_title(live.title)
+    end
+  end
+
+  feature 'Create an entry' do
     given(:user) { create(:user) }
 
     background { ActionMailer::Base.deliveries.clear }

--- a/spec/features/entry_pages_spec.rb
+++ b/spec/features/entry_pages_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'EntryPages', type: :feature do
       visit live_entries_path(live)
 
       expect(page).to have_title(live.title)
+      expect(page).to have_link('エントリーする', href: new_live_entry_path(live))
       expect(page).to have_content('Visible song')
       expect(page).not_to have_content('Invisible song')
     end

--- a/spec/features/live_pages_spec.rb
+++ b/spec/features/live_pages_spec.rb
@@ -34,23 +34,6 @@ RSpec.feature 'LivePages', type: :feature do
       expect(page).to have_content(user.handle)
       expect(page).not_to have_link(href: live.album_url)
     end
-
-    context 'with future live' do
-      given(:draft_live) { create(:live, date: 1.month.from_now) }
-      given(:draft_song_user_will_play) { create(:song, live: draft_live, name: 'Visible Song') }
-      given!(:draft_song_user_will_not_play) { create(:song, live: draft_live, name: 'Invisible Song') }
-
-      background do
-        create(:playing, user: user, song: draft_song_user_will_play)
-        log_in_as user
-      end
-
-      scenario 'A logged-in user can see the draft song only he/she will play' do
-        visit live_path(draft_live)
-        expect(page).to have_content(draft_song_user_will_play.name)
-        expect(page).not_to have_content(draft_song_user_will_not_play.name)
-      end
-    end
   end
 
   feature 'Add live' do

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Authentication", type: :request do
       end
 
       describe 'submitting to the create action' do
-        before { post live_entry_path(live) }
+        before { post live_entries_path(live) }
         specify { expect(response).to redirect_to(login_path) }
       end
     end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -35,7 +35,12 @@ RSpec.describe "Authentication", type: :request do
     describe 'in the Entries controller' do
       let(:live) { create(:draft_live) }
 
-      describe 'visiting the new entry page' do
+      describe 'visiting the entry list page' do
+        before { get live_entries_path(live) }
+        specify { expect(response).to redirect_to(login_path) }
+      end
+
+      describe 'visiting the entry form' do
         before { get new_live_entry_path(live) }
         specify { expect(response).to redirect_to(login_path) }
       end


### PR DESCRIPTION
This resolves #108 and relates to #106 

## 課題

- `LivesController#show` において，同じビューを用いているのにも関わらず，ライブがエントリー受付中かどうかで表示内容が大きく変わってしまう
- エントリーフォームが簡単に見つからない
  - Live List を見ても一目でエントリー募集中とはわからない #108

## 修正方針

- 新たに `/lives/:id/entries` というパスを追加し，ライブがエントリー中の場合は `/lives/:id` からそちらにリダイレクトするようにする
- Live List にはエントリー募集中のライブは表示しないようにし，ナビゲーションバー右上に Entry ボタンを追加する

## スクリーンショット

/lives/:id/entries

![/lives/:id/entries](https://user-images.githubusercontent.com/6823454/31045240-269467ac-a61a-11e7-87f0-d56f5d14d357.png)