### PR TITLE
Fix `PG::UniqueViolation: ERROR: duplicate key value violates unique constraint`

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -17,6 +17,8 @@ class EntriesController < ApplicationController
       flash[:danger] = 'メールの送信に失敗しました'
     end
     redirect_to @song.live
+  rescue ActiveRecord::RecordNotUnique
+    @song.add_error_for_duplicated_user
   end
 
   private

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -28,6 +28,9 @@ class SongsController < ApplicationController
     else
       render :new
     end
+  rescue ActiveRecord::RecordNotUnique
+    @song.add_error_for_duplicated_user
+    render :new
   end
 
   def edit
@@ -47,6 +50,9 @@ class SongsController < ApplicationController
         format.js { flash.now[:danger] = @song.errors.full_messages }
       end
     end
+  rescue ActiveRecord::RecordNotUnique
+    @song.add_error_for_duplicated_user
+    render :edit
   end
 
   def destroy

--- a/app/models/playing.rb
+++ b/app/models/playing.rb
@@ -4,7 +4,7 @@ class Playing < ApplicationRecord
 
   before_save :format_inst
 
-  validates :user_id, presence: true, uniqueness: { scope: :song_id }
+  validates :user_id, presence: true
   validates :song, presence: true
 
   scope :count_insts, -> { group(:inst).count(:id) }

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -79,6 +79,10 @@ class Song < ApplicationRecord
     SongMailer.entry(self, applicant).deliver_now
   end
 
+  def add_error_for_duplicated_user
+    errors.add(:playings, 'が重複しています')
+  end
+
   def previous(logged_in = false)
     return nil if order.blank?
     allowed_statuses = if logged_in

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -34,6 +34,7 @@ ja:
         time: 時間
         status: 公開設定
         comment: コメント
+        playings: 演者
       playing:
         user: メンバー
         inst: 楽器

--- a/spec/features/song_pages_spec.rb
+++ b/spec/features/song_pages_spec.rb
@@ -139,15 +139,14 @@ RSpec.feature 'SongPages', type: :feature do
       end
     end
 
-    scenario 'An admin user not save changes with invalid information' do
-      new_song_name = 'ニューソング'
+    scenario 'An admin user can save changes with valid information' do
       visit edit_song_path(song)
 
-      fill_in '曲名', with: new_song_name
+      fill_in '曲名', with: 'ニューソング'
       click_button 'Save'
 
       expect(page).to have_selector('.alert-success')
-      expect(song.reload.name).to eq new_song_name
+      expect(song.reload.name).to eq 'ニューソング'
     end
   end
 

--- a/spec/features/song_pages_spec.rb
+++ b/spec/features/song_pages_spec.rb
@@ -65,19 +65,37 @@ RSpec.feature 'SongPages', type: :feature do
   end
 
   feature 'song creation' do
-    given(:admin) { create(:admin) }
     given(:live) { create(:live) }
     background do
-      log_in_as admin
+      create_list(:user, 3)
+      log_in_as create(:admin)
+    end
+
+    context 'with invalid information' do
+
+      scenario 'An admin user cannot create the song with an empty title' do
+        visit new_song_path(live_id: live.id)
+
+        expect { click_button 'Add' }.not_to change(Song, :count)
+        expect(page).to have_selector('.alert-danger')
+        expect(page).to have_content('曲名を入力してください')
+      end
+
+      scenario 'An admin user cannot create the song with duplicated players', js: true do
+        visit new_song_path(live_id: live.id)
+
+        fill_in '曲名', with: 'テストソング'
+        click_button id: 'add-member'
+
+        expect { click_button 'Add' }.not_to change(Song, :count)
+        expect(page).to have_selector('.alert-danger')
+        expect(page).to have_content('演者が重複しています')
+      end
+    end
+
+    scenario 'An admin user can create the song with valid information' do
       visit new_song_path(live_id: live.id)
-    end
 
-    scenario 'with invalid information' do
-      expect { click_button 'Add' }.not_to change(Song, :count)
-      expect(page).to have_selector('.alert-danger')
-    end
-
-    scenario 'with valid information' do
       expect(page).to have_title('Add song')
 
       fill_in '曲名', with: 'テストソング'
@@ -88,23 +106,41 @@ RSpec.feature 'SongPages', type: :feature do
   end
 
   feature 'song edition' do
-    given(:admin) { create(:admin) }
-
-
-
-    scenario 'An admin user cannot save changes with invalid information' do
+    given(:admin) { create(:admin, last_name: '管', first_name: '理人') }
+    given(:users) { create_list(:user, 3) }
+    background do
+      users.each do |user|
+        create(:playing, song: song, user: user)
+      end
       log_in_as admin
-      visit edit_song_path(song)
+    end
 
-      fill_in '曲名', with: ''
-      click_button 'Save'
+    context 'with invalid information' do
 
-      expect(page).to have_selector('.alert-danger')
+      scenario 'An admin user cannot save changes with the empty title' do
+        visit edit_song_path(song)
+
+        fill_in '曲名', with: ''
+        click_button 'Save'
+
+        expect(page).to have_selector('.alert-danger')
+        expect(page).to have_content('曲名を入力してください')
+      end
+
+      scenario 'An admin user cannot save changes with duplicated players' do
+        visit edit_song_path(song)
+
+        select admin.full_name, from: 'song[playings_attributes][0][user_id]'
+        select admin.full_name, from: 'song[playings_attributes][1][user_id]'
+        click_button 'Save'
+
+        expect(page).to have_selector('.alert-danger')
+        expect(page).to have_content('演者が重複しています')
+      end
     end
 
     scenario 'An admin user not save changes with invalid information' do
       new_song_name = 'ニューソング'
-      log_in_as admin
       visit edit_song_path(song)
 
       fill_in '曲名', with: new_song_name

--- a/spec/models/playing_spec.rb
+++ b/spec/models/playing_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Playing, type: :model do
     it { is_expected.not_to be_valid }
   end
 
-  describe 'when the combination of user and song is already taken' do
+  xdescribe 'when the combination of user and song is already taken' do
     before { playing.dup.save }
     it { is_expected.not_to be_valid }
   end


### PR DESCRIPTION
Fix #115 
Fix #27 

## 課題

- 1つの曲で演者を重複して登録しようとすると `PG::UniqueViolation: ERROR: duplicate key value violates unique constraint` により 500 が返る

## 修正方針

- モデル `Playing` の uniqueness validation は諦めて ActiveRecord レベルのエラー `ActiveRecord::RecordNotUnique` を rescue するようにする