### PR TITLE
Fix instrument counts in member detail pages

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,10 @@ class User < ApplicationRecord
     songs.performed
   end
 
+  def performed_playings
+    playings.includes(song: :live).where('lives.date <= ?', Time.zone.today)
+  end
+
   def played?(song)
     song.playings.pluck(:user_id).include?(id)
   end

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -3,7 +3,7 @@ json.cache_if! !authenticated?, ['v1', @user] do
   json.name @user.display_name(authenticated?)
 end
 json.insts do
-  json.array! Playing.resolve_insts(@user.playings.count_insts) do |inst, count|
+  json.array! Playing.resolve_insts(@user.performed_playings.count_insts) do |inst, count|
     json.inst inst
     json.count count
   end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -18,7 +18,7 @@
           %mark= total
           曲
         %ul.list-group.list-group-flush
-          - Playing.resolve_insts(@user.playings.count_insts).each do |inst, count|
+          - Playing.resolve_insts(@user.performed_playings.count_insts).each do |inst, count|
             - unless inst.blank?
               %li.list-group-item.d-flex.justify-content-between.align-items-center
                 = inst


### PR DESCRIPTION
Fix #119 

エントリー受付中のライブに関するものを含まない `User#performed_playings` を追加し，`User#playings` ではなくこちらを用いるようにしました。