### PR TITLE
Add created_at and updated_at columns to the entries table and enable to change the order by admins

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -4,7 +4,12 @@ class EntriesController < ApplicationController
   before_action :draft_live
 
   def index
-    @songs = @live.songs.order(:time, :order, created_at: :desc).includes(playings: :user).select { |song| song.editable?(current_user) }
+    songs = if params[:order] == 'created_at' || params[:order] == 'updated_at'
+              @live.songs.order(params[:order] => :desc).includes(playings: :user)
+            else
+              @live.songs.order(:time, :order, created_at: :desc).includes(playings: :user)
+            end
+    @songs = songs.select { |song| song.editable?(current_user) }
   end
 
   def new

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -4,7 +4,7 @@ class EntriesController < ApplicationController
   before_action :draft_live
 
   def index
-    @entries = @live.songs.played_order.includes(playings: :user).select { |song| song.editable?(current_user) }
+    @songs = @live.songs.order(:time, :order, created_at: :desc).includes(playings: :user).select { |song| song.editable?(current_user) }
   end
 
   def new

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -4,15 +4,39 @@
     = @live.name
     %small.text-muted
       = @live.place.present? ? " #{I18n.l(@live.date)} @#{@live.place} " : I18n.l(@live.date)
-    - if @entries.present?
+    - if @songs.present?
       = link_to icon('paper-plane') + ' エントリーする', new_live_entry_path(@live), class: 'btn btn-info btn-lg float-md-right mt-2'
 
 
 - if current_user.admin_or_elder?
   = render 'lives/btn_toolbar', live: @live
 
-- if @entries.present?
-  = render 'songs/songs_table', songs: @entries
+- if @songs.present?
+  %table.table.table-responsive.table-striped.table-sm
+    %thead
+      %tr
+        %th Entered
+        %th Updated
+        %th #
+        %th Song
+        %th Artist
+        %th Members
+        %th
+    %tbody
+      - @songs.each do |song|
+        %tr
+          %td= song.created_at.strftime('%m/%d %R')
+          %td= song.updated_at.to_i == song.created_at.to_i ? '' : song.updated_at.strftime('%m/%d %R')
+          %td= song.time_order
+          %td
+            = song.name
+            = status_icon(song) if logged_in? && current_user.played?(song)
+          %td= link_to song.artist, songs_path(q: song.artist)
+          %td
+            %ul.list-inline.mb-0
+              = render sort_by_inst(song.playings)
+          %td= link_to icon('pencil'), edit_song_path(song)
+
 - else
   .row.mb-3
     .col-md-6.ml-auto.mr-auto

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -10,6 +10,14 @@
 
 - if current_user.admin_or_elder?
   = render 'lives/btn_toolbar', live: @live
+  %aside.card.mb-3
+    .card-body.form-inline
+      = label_tag :order_select, '並び替え', class: 'mr-2'
+      = select_tag :order,
+                   options_for_select({ '演奏順': 'default', '作成日時': 'created_at', '変更日時': 'updated_at' }, params[:order]),
+                   id: :order_select,
+                   class: 'form-control',
+                   onchange: "location.href='#{request.path}?order=' + $(this).val();"
 
 - if @songs.present?
   %table.table.table-responsive.table-striped.table-sm


### PR DESCRIPTION
resolve #129 

## 課題

- エントリー時点では time も order も設定されていないため，エントリー一覧の順序が決まらない

## 修正方針

- デフォルトの順序を `Song.order(:time, :order, created_at: :desc)` とし，time と order が設定されていない場合はエントリー日時の降順になるようにしました
- 管理者は「演奏順・作成日時・更新日時」で並び替えできるようにしました

## スクリーンショット

![スクリーンショット](https://user-images.githubusercontent.com/6823454/32142318-508b065e-bcd8-11e7-86a7-13a2f117b107.png)

---

@rhinocerosSai レビューお願いします。