### PR TITLE
Show confirmation dialog before sending an entry

### DIFF
--- a/app/views/entries/_form.html.haml
+++ b/app/views/entries/_form.html.haml
@@ -24,4 +24,4 @@
     = f.label :notes, '備考'
     = f.text_area :notes, id: 'song_notes', class: 'form-control', rows: 3
 
-  = f.submit 'Send', class: 'btn btn-primary'
+  = f.submit 'Send', data: { confirm: '本当に送信しますか？' }, class: 'btn btn-primary'

--- a/spec/features/entry_pages_spec.rb
+++ b/spec/features/entry_pages_spec.rb
@@ -34,7 +34,9 @@ RSpec.feature 'EntryPages', type: :feature do
       expect(page).to have_title('Entry')
 
       fill_in '曲名', with: 'テストソング'
-      click_button 'Send'
+      accept_confirm do
+        click_button 'Send'
+      end
 
       expect(page).to have_selector('.alert-success')
       expect(ActionMailer::Base.deliveries.size).to eq 1
@@ -44,7 +46,9 @@ RSpec.feature 'EntryPages', type: :feature do
       log_in_as user
       visit new_live_entry_path(live)
 
-      click_button 'Send'
+      accept_confirm do
+        click_button 'Send'
+      end
 
       expect(page).to have_selector('.alert-danger')
       expect(ActionMailer::Base.deliveries.size).to eq 0


### PR DESCRIPTION
resolve #137

エントリー送信前に「本当に送信しますか？」という確認を出すようにしました。