### PR TITLE
Make draft lives publishable

### DIFF
--- a/app/controllers/api/v1/lives_controller.rb
+++ b/app/controllers/api/v1/lives_controller.rb
@@ -3,9 +3,9 @@ class Api::V1::LivesController < Api::V1::ApplicationController
   def index
     limit = params[:limit].to_i
     @lives = if limit.positive?
-               Live.performed.order_by_date.limit(limit)
+               Live.published.order_by_date.limit(limit)
              else
-               Live.performed.order_by_date
+               Live.published.order_by_date
              end
   end
 

--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::SongsController < Api::V1::ApplicationController
     @songs = if params[:q].present?
                Song.search(params[:q]).page(params[:page]).records(includes: [:live, { playings: :user }])
              else
-               Song.performed.includes(playings: :user).page(params[:page]).order_by_live
+               Song.published.includes(playings: :user).page(params[:page]).order_by_live
              end
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::UsersController < Api::V1::ApplicationController
   end
 
   def show
-    @playings = Playing.where(song_id: @user.performed_songs.pluck('songs.id'))
+    @playings = Playing.where(song_id: @user.songs.published.pluck('songs.id'))
   end
 
   private

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -44,7 +44,7 @@ class EntriesController < ApplicationController
   end
 
   def draft_live
-    redirect_to root_url unless @live.draft?
+    redirect_to root_url if @live.published?
   end
 
   def song_params

--- a/app/controllers/lives_controller.rb
+++ b/app/controllers/lives_controller.rb
@@ -2,10 +2,10 @@ class LivesController < ApplicationController
   before_action :set_live, only: %i[show edit update destroy]
   before_action :logged_in_user, except: %i[index show]
   before_action :admin_or_elder_user, except: %i[index show]
-  before_action :performed_live, only: :show
+  before_action :published_live, only: :show
 
   def index
-    @lives = Live.performed.order_by_date
+    @lives = Live.published.order_by_date
   end
 
   def show
@@ -56,8 +56,8 @@ class LivesController < ApplicationController
     @live = Live.includes(:songs).find(params[:id])
   end
 
-  def performed_live
-    redirect_to live_entries_url(@live) if @live.draft?
+  def published_live
+    redirect_to live_entries_url(@live) unless @live.published?
   end
 
   def live_params

--- a/app/controllers/publishes_controller.rb
+++ b/app/controllers/publishes_controller.rb
@@ -1,0 +1,18 @@
+class PublishesController < ApplicationController
+  before_action :admin_user
+  before_action :set_live
+  before_action :draft_live
+
+  def create
+  end
+
+  private
+
+  def set_live
+    @live = Live.find(params[:live_id])
+  end
+
+  def draft_live
+    redirect_to root_url if @live.published?
+  end
+end

--- a/app/controllers/publishes_controller.rb
+++ b/app/controllers/publishes_controller.rb
@@ -4,6 +4,9 @@ class PublishesController < ApplicationController
   before_action :draft_live
 
   def create
+    @live.publish
+    flash[:success] = '公開しました'
+    redirect_to @live
   end
 
   private

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -10,7 +10,7 @@ class SongsController < ApplicationController
     @songs = if params[:q].present?
                Song.search(params[:q]).page(params[:page]).records(includes: [:live, { playings: :user }])
              else
-               Song.performed.includes(playings: :user).page(params[:page]).order_by_live
+               Song.published.includes(playings: :user).page(params[:page]).order_by_live
              end
   end
 
@@ -101,6 +101,6 @@ class SongsController < ApplicationController
   end
 
   def draft_song?
-    @song.draft?
+    !@song.published?
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,14 +10,13 @@ class StaticPagesController < ApplicationController
   end
 
   def stats
-    range = if params[:y] && Live.years.include?(params[:y].to_i)
+    range = if params[:y] && Live.years.include?(params[:y]&.to_i)
               start = Date.new(params[:y].to_i, 4, 1)
-              (start...start + 1.year)
+              start...start + 1.year
             else
-              (1.year.ago..Time.zone.today)
+              1.year.ago..Time.zone.today
             end
-
-    @songs = Song.includes(:live).where('lives.date' => range)
-    @playings = Playing.includes(song: :live).where('lives.date' => range)
+    @songs = Song.includes(:live).published.where('lives.date': range)
+    @playings = Playing.includes(song: :live).published.where('lives.date': range)
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,7 +2,7 @@ class StaticPagesController < ApplicationController
   def home
     today = Time.zone.today
     @song = Rails.cache.fetch("pickup/#{today}", expires_in: 1.day) { Song.includes(playings: :user).pickup(today) }
-    @lives = Live.includes(:songs).performed.order_by_date.where('date >= ?', 1.month.ago)
+    @lives = Live.includes(:songs).published.order_by_date.where('date >= ?', 1.month.ago)
     return unless logged_in?
     @regular_meeting = Rails.cache.fetch("regular_meeting/#{today}", expires_in: 1.day) do
       RegularMeeting.new(today)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @playings = Playing.where(song_id: @user.performed_songs.pluck('songs.id'))
+    @playings = Playing.where(song_id: @user.songs.published.pluck('songs.id'))
   end
 
   def new

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -4,12 +4,16 @@ module Searchable
   included do
     include Elasticsearch::Model
 
-    after_commit on: %i[create update] do
-      __elasticsearch__.index_document unless draft?
+    after_commit on: [:create] do
+      __elasticsearch__.index_document if published?
+    end
+
+    after_commit on: [:update] do
+      __elasticsearch__.update_document if published?
     end
 
     after_commit on: [:destroy] do
-      __elasticsearch__.delete_document unless draft?
+      __elasticsearch__.delete_document if published?
     end
 
     def as_indexed_json(options = {})

--- a/app/models/live.rb
+++ b/app/models/live.rb
@@ -29,4 +29,9 @@ class Live < ApplicationRecord
   def nf?
     name.include?('NF')
   end
+
+  def publish
+    update(published: true, published_at: Time.zone.now)
+    songs.includes(:playings).import
+  end
 end

--- a/app/models/live.rb
+++ b/app/models/live.rb
@@ -1,14 +1,16 @@
 class Live < ApplicationRecord
   has_many :songs, dependent: :restrict_with_exception
 
+  before_save :publish_past_live
+
   validates :name, presence: true, uniqueness: { scope: :date }
   validates :date, presence: true
   validates :album_url, format: /\A#{URI.regexp(%w[http https])}\z/, allow_blank: true
 
   scope :order_by_date, -> { order(date: :desc) }
   scope :nendo, ->(year) { where(date: Date.new(year, 4, 1)...Date.new(year + 1, 4, 1)) }
-  scope :drafts, -> { where('date > ?', Time.zone.today) }
-  scope :performed, -> { where('date <= ?', Time.zone.today) }
+  scope :drafts, -> { where(published: false) }
+  scope :published, -> { where(published: true) }
 
   def self.years
     Live.order_by_date.select(:date).map(&:nendo).uniq
@@ -22,10 +24,6 @@ class Live < ApplicationRecord
     date.mon < 4 ? date.year - 1 : date.year
   end
 
-  def draft?
-    date > Time.zone.today
-  end
-
   def nf?
     name.include?('NF')
   end
@@ -33,5 +31,13 @@ class Live < ApplicationRecord
   def publish
     update(published: true, published_at: Time.zone.now)
     songs.includes(:playings).import
+  end
+
+  private
+
+  def publish_past_live
+    return if date >= Time.zone.today
+    self.published = true
+    self.published_at = Time.zone.now
   end
 end

--- a/app/models/playing.rb
+++ b/app/models/playing.rb
@@ -11,6 +11,7 @@ class Playing < ApplicationRecord
 
   scope :count_insts, -> { group(:inst).count(:id) }
   scope :count_members_per_song, -> { group(:song_id).count(:id) }
+  scope :published, -> { includes(song: :live).where('lives.published': true) }
 
   def self.resolve_insts(inst_to_count)
     single_inst_to_count = inst_to_count.reject { |inst, _| inst.blank? || inst.include?('&') }

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -17,7 +17,7 @@ class Song < ApplicationRecord
   accepts_nested_attributes_for :playings, allow_destroy: true
 
   delegate :title, :name, to: :live, prefix: true
-  delegate :date, :draft?, :nf?, to: :live
+  delegate :date, :published?, :nf?, to: :live
   delegate :size, to: :playings, prefix: true
 
   enum status: { secret: 0, closed: 1, open: 2 }
@@ -30,7 +30,7 @@ class Song < ApplicationRecord
 
   scope :played_order, -> { order(:time, :order) }
   scope :order_by_live, -> { includes(:live).order('lives.date DESC', :time, :order) }
-  scope :performed, -> { eager_load(:live).where('lives.date <= ?', Time.zone.today) }
+  scope :published, -> { eager_load(:live).where('lives.published': true) }
 
   def self.pickup(date = Time.zone.today)
     random = Random.new(date.to_time.to_i)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,14 +65,6 @@ class User < ApplicationRecord
     admin? || elder?
   end
 
-  def performed_songs
-    songs.performed
-  end
-
-  def performed_playings
-    playings.includes(song: :live).where('lives.date <= ?', Time.zone.today)
-  end
-
   def played?(song)
     song.playings.pluck(:user_id).include?(id)
   end

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -3,13 +3,13 @@ json.cache_if! !authenticated?, ['v1', @user] do
   json.name @user.display_name(authenticated?)
 end
 json.insts do
-  json.array! Playing.resolve_insts(@user.performed_playings.count_insts) do |inst, count|
+  json.array! Playing.resolve_insts(@user.playings.published.count_insts) do |inst, count|
     json.inst inst
     json.count count
   end
 end
 json.songs do
-  json.array! @user.performed_songs.order_by_live do |song|
+  json.array! @user.songs.published.order_by_live do |song|
     json.cache_if! !authenticated?, ['v1', song] do
       json.partial! 'api/v1/songs/song', song: song
       json.live song.live, partial: 'api/v1/lives/live', as: :live

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -9,7 +9,13 @@
 
 
 - if current_user.admin_or_elder?
-  = render 'lives/btn_toolbar', live: @live
+  .btn-toolbar.justify-content-end.mb-3{ role: 'toolbar' }
+    .btn-group.mr-2{ role: 'group' }
+      = link_to 'Publish', live_publish_path(@live), method: :post, data: { confirm: "本当に公開しますか？\nこの操作は取り消せません。" }, class: 'btn btn-outline-danger'
+    .btn-group{ role: 'group' }
+      = link_to icon('pencil') + ' Edit', edit_live_path(@live), class: 'btn btn-outline-primary'
+      - unless @live.songs.exists?
+        = link_to icon('trash') + ' Delete', @live, method: :delete, class: 'btn btn-outline-danger'
   %aside.card.mb-3
     .card-body.form-inline
       = label_tag :order_select, '並び替え', class: 'mr-2'

--- a/app/views/lives/_btn_toolbar.html.haml
+++ b/app/views/lives/_btn_toolbar.html.haml
@@ -1,7 +1,0 @@
-.btn-toolbar.justify-content-end.mb-3{ role: 'toolbar' }
-  .btn-group.mr-2{ role: 'group' }
-    = link_to icon('plus-circle') + ' Add song', new_song_path(live_id: live.id), class: 'btn btn-outline-secondary'
-  .btn-group{ role: 'group' }
-    = link_to icon('pencil') + ' Edit', edit_live_path(live), class: 'btn btn-outline-primary'
-    - unless live.songs.exists?
-      = link_to icon('trash') + ' Delete', live, method: :delete, class: 'btn btn-outline-danger'

--- a/app/views/lives/show.html.haml
+++ b/app/views/lives/show.html.haml
@@ -9,7 +9,13 @@
         = link_to icon('picture-o') + ' Album', @live.album_url, class: 'btn btn-primary btn-lg float-md-right mt-2', target: '_blank', 'data-toggle': 'tooltip', 'data-placement': 'top', title: '写真を共有しよう！'
 
   - if logged_in? && current_user.admin_or_elder?
-    = render 'btn_toolbar', live: @live
+    .btn-toolbar.justify-content-end.mb-3{ role: 'toolbar' }
+      .btn-group.mr-2{ role: 'group' }
+        = link_to icon('plus-circle') + ' Add song', new_song_path(live_id: @live.id), class: 'btn btn-outline-secondary'
+      .btn-group{ role: 'group' }
+        = link_to icon('pencil') + ' Edit', edit_live_path(@live), class: 'btn btn-outline-primary'
+        - unless @live.songs.exists?
+          = link_to icon('trash') + ' Delete', @live, method: :delete, class: 'btn btn-outline-danger'
 
   - if @live.nf?
     = render 'songs/songs_table', songs: @live.songs.played_order.includes(playings: :user)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,5 @@
 - provide(:title, @user.display_name(logged_in?))
-- total = @user.performed_songs.count
+- total = @user.songs.published.count
 %header.page-header
   %h1
     = @user.display_name(logged_in?)
@@ -18,7 +18,7 @@
           %mark= total
           曲
         %ul.list-group.list-group-flush
-          - Playing.resolve_insts(@user.performed_playings.count_insts).each do |inst, count|
+          - Playing.resolve_insts(@user.playings.published.count_insts).each do |inst, count|
             - unless inst.blank?
               %li.list-group-item.d-flex.justify-content-between.align-items-center
                 = inst
@@ -29,7 +29,7 @@
           %h6.card-header アーティスト
           .list-group.list-group-flush
             - last_count = 0
-            - @user.performed_songs.group(:artist).count.select { |a, _| a.present? }.sort { |(_, c1), (_, c2)| c2 <=> c1 }.each_with_index do |(artist, count), i|
+            - @user.songs.published.group(:artist).count.select { |a, _| a.present? }.sort { |(_, c1), (_, c2)| c2 <=> c1 }.each_with_index do |(artist, count), i|
               - break if count < 2 || i >= 5 && count != last_count
               = link_to songs_path(q: artist),
                         class: 'list-group-item list-group-item-action d-flex justify-content-between align-items-center' do
@@ -77,7 +77,7 @@
               %dd= link_to @user.url, @user.url, target: '_blank'
           = simple_format(@user.intro)
 
-  = render 'songs/songs_table', songs: @user.performed_songs.order_by_live.includes(playings: :user)
+  = render 'songs/songs_table', songs: @user.songs.published.order_by_live.includes(playings: :user)
 
   - if logged_in? && current_user.admin?
     .btn-toolbar.justify-content-end{ role: 'toolbar' }
@@ -88,6 +88,6 @@
           - else
             = link_to 'アカウントを無効にする', user_activation_path(@user), method: :delete, data: { confirm: '本当にアカウントを無効にしますか？' }, class: 'btn btn-outline-warning'
             = link_to '管理者にする', user_admin_path(@user), method: :post, data: { confirm: '本当に管理者にしますか？' }, class: 'btn btn-outline-danger'
-      - elsif !@user.performed_songs.exists?
+      - elsif !@user.songs.published.exists?
         .btn-group{ role: 'group' }
           = link_to icon('trash') + ' Delete', @user, method: :delete, class: 'btn btn-outline-danger'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   resources :lives do
     resources :entries, only: %i[index new create]
+    resource :publish, only: :create
   end
 
   resources :users, path: :members do

--- a/spec/factories/lives.rb
+++ b/spec/factories/lives.rb
@@ -4,9 +4,13 @@ FactoryBot.define do
     name { "#{date.mon}月ライブ" }
     place '4共21'
     album_url 'https://goo.gl/photos/o94hbpFHQtcjzjwj6'
+    published true
+    published_at Time.zone.now
 
     factory :draft_live do
       sequence(:date) { |n| n.month.from_now }
+      published false
+      published_at nil
     end
   end
 end

--- a/spec/features/entry_pages_spec.rb
+++ b/spec/features/entry_pages_spec.rb
@@ -22,6 +22,23 @@ RSpec.feature 'EntryPages', type: :feature do
     end
   end
 
+  feature 'Publish the live' do
+    given(:admin) { create(:admin) }
+    background do
+      log_in_as admin
+    end
+
+    scenario 'An admin user can publish the live' do
+      visit live_entries_path(live)
+
+      click_link 'Publish'
+
+      expect(live.reload.published).to be_truthy
+      expect(live.published_at).not_to be_nil
+      expect(page).to have_selector('.alert-success')
+    end
+  end
+
   feature 'Create an entry' do
     given(:user) { create(:user) }
 

--- a/spec/features/entry_pages_spec.rb
+++ b/spec/features/entry_pages_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'EntryPages', type: :feature do
   feature 'Publish the live' do
     given(:admin) { create(:admin) }
     background do
+      Song.__elasticsearch__.create_index!
       log_in_as admin
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -146,20 +146,4 @@ RSpec.describe User, type: :model do
       specify { expect(user_for_invalid_password).to be_falsey }
     end
   end
-
-  describe '#performed_songs' do
-    let(:user) { create(:user) }
-    let(:performed_song) { create(:song, live: create(:live, date: 1.month.ago)) }
-    let(:entering_song) { create(:song, live: create(:live, date: 1.month.from_now)) }
-    before do
-      create(:playing, user: user, song: performed_song)
-      create(:playing, user: user, song: entering_song)
-    end
-
-    it 'should include only performed songs' do
-      result = user.performed_songs
-      expect(result).to include(performed_song)
-      expect(result).not_to include(entering_song)
-    end
-  end
 end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -134,5 +134,14 @@ RSpec.describe "Authentication", type: :request do
         specify { expect(response).to redirect_to(root_path) }
       end
     end
+
+    describe 'in the Publishes controller' do
+      let(:live) { create(:draft_live) }
+
+      describe 'submitting to the create action' do
+        before { post live_publish_path(live) }
+        specify { expect(response).to redirect_to(root_path) }
+      end
+    end
   end
 end


### PR DESCRIPTION
resolve #145 

事前に 2705d54cd3f149b5ba8f8686f3718e62653353df と d3f9e1ebe1076bcf616d05671800f2ed56561e99 のコミットで lives テーブルに `published` と `published_at` カラムを追加して，過去の曲は全てこのカラムを以下のスクリプトで更新してあります。 

```ruby
Live.performed.each { |live| live.update(published: true, published_at: live.date) }
```

## スクリーンショット

![localhost-3000-lives-108-entries_ipad_pro_](https://user-images.githubusercontent.com/6823454/32366235-935847a8-c0c0-11e7-9bbb-7dd1bc53b1b7.png)

---
@rhinocerosSai レビューお願いします。