### PR TITLE
Make entry mail be sent to applicant as cc

### DIFF
--- a/app/mailers/entry_mailer.rb
+++ b/app/mailers/entry_mailer.rb
@@ -5,6 +5,7 @@ class EntryMailer < ApplicationMailer
     @entry = entry
     reply_to = %("#{entry.applicant_name}" <#{entry.applicant_email}>)
     from = %("#{entry.applicant_name}" <noreply@livelog.ku-unplugged.net>)
-    mail from: from, reply_to: reply_to, subject: "#{entry.live_name} 曲申請「#{entry.title}」"
+    cc = %("#{entry.applicant_name}" <#{entry.applicant_email}>)
+    mail from: from, cc: cc, reply_to: reply_to, subject: "#{entry.live_name} 曲申請「#{entry.title}」"
   end
 end

--- a/app/mailers/entry_mailer.rb
+++ b/app/mailers/entry_mailer.rb
@@ -3,9 +3,8 @@ class EntryMailer < ApplicationMailer
 
   def entry(entry)
     @entry = entry
-    reply_to = %("#{entry.applicant_name}" <#{entry.applicant_email}>)
     from = %("#{entry.applicant_name}" <noreply@livelog.ku-unplugged.net>)
     cc = %("#{entry.applicant_name}" <#{entry.applicant_email}>)
-    mail from: from, cc: cc, reply_to: reply_to, subject: "#{entry.live_name} 曲申請「#{entry.title}」"
+    mail from: from, cc: cc, subject: "#{entry.live_name} 曲申請「#{entry.title}」"
   end
 end

--- a/app/mailers/song_mailer.rb
+++ b/app/mailers/song_mailer.rb
@@ -1,6 +1,5 @@
 class SongMailer < ApplicationMailer
   default to: 'sankichi92@ku-unplugged.net'
-  default reply_to: 'sankichi92@ku-unplugged.net'
 
   def pickup_song(song = Song.pickup)
     @song = song

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,4 @@
 class UserMailer < ApplicationMailer
-  default reply_to: 'sankichi92@ku-unplugged.net'
-
   def account_activation(user, inviter)
     @user = user
     @inviter = inviter

--- a/spec/mailers/entry_mailer_spec.rb
+++ b/spec/mailers/entry_mailer_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe EntryMailer, type: :mailer do
       expect(mail.to).to eq(['pa@ku-unplugged.net'])
       expect(mail.from).to eq(['noreply@livelog.ku-unplugged.net'])
       expect(mail.cc).to eq([applicant.email])
-      expect(mail.reply_to).to eq([applicant.email])
     end
 
     it 'renders the text body' do

--- a/spec/mailers/entry_mailer_spec.rb
+++ b/spec/mailers/entry_mailer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe EntryMailer, type: :mailer do
       expect(mail.subject).to eq("#{song.live_name} 曲申請「#{song.title}」")
       expect(mail.to).to eq(['pa@ku-unplugged.net'])
       expect(mail.from).to eq(['noreply@livelog.ku-unplugged.net'])
+      expect(mail.cc).to eq([applicant.email])
       expect(mail.reply_to).to eq([applicant.email])
     end
 

--- a/spec/mailers/song_mailer_spec.rb
+++ b/spec/mailers/song_mailer_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe SongMailer, type: :mailer do
       expect(mail.to).to eq(['sankichi92@ku-unplugged.net'])
       expect(mail.from).to eq(['noreply@livelog.ku-unplugged.net'])
       expect(mail.bcc).to eq(users.map(&:email))
-      expect(mail.reply_to).to eq(['sankichi92@ku-unplugged.net'])
     end
 
     it 'renders the text body' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.subject).to eq("#{inviter.name} さんが LiveLog に招待しています")
       expect(mail.to).to eq([user.email])
       expect(mail.from).to eq(['noreply@livelog.ku-unplugged.net'])
-      expect(mail.reply_to).to eq(['sankichi92@ku-unplugged.net'])
     end
 
     it 'renders the text body' do
@@ -35,7 +34,6 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.subject).to eq('パスワード再設定のご案内')
       expect(mail.to).to eq([user.email])
       expect(mail.from).to eq(['noreply@livelog.ku-unplugged.net'])
-      expect(mail.reply_to).to eq(['sankichi92@ku-unplugged.net'])
     end
 
     it 'renders the text body' do


### PR DESCRIPTION
#125 

viewファイルが自動で取得されるため, `_entry....` の共通ファイルを作り, 読み込むようにしています.