### PR TITLE
Revert "Update elasticsearch gems to 7.x"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       elasticsearch:
-        image: elasticsearch:7.3.2
+        image: elasticsearch:6.4.0
         ports:
           - 9200:9200
         options: --env "discovery.type=single-node" --health-cmd "curl http://localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 10

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,9 @@ gem 'aws-sdk-s3', require: false
 gem 'bootsnap', require: false
 gem 'cloudinary'
 gem 'commonmarker'
-gem 'elasticsearch', '~> 7.0'
+gem 'elasticsearch', '~> 6.8'
 gem 'elasticsearch-dsl'
-gem 'elasticsearch-rails', '~> 7.0'
+gem 'elasticsearch-rails', '~> 6.1'
 gem 'font-awesome-sass'
 gem 'graphiql-rails'
 gem 'haml-rails'
@@ -41,7 +41,7 @@ gem 'slack-ruby-client'
 gem 'twitter'
 
 # Must be after 'kaminari'
-gem 'elasticsearch-model', '~> 7.0'
+gem 'elasticsearch-model', '~> 6.1'
 
 # API
 gem 'batch-loader'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,18 +121,18 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    elasticsearch (7.9.0)
-      elasticsearch-api (= 7.9.0)
-      elasticsearch-transport (= 7.9.0)
-    elasticsearch-api (7.9.0)
+    elasticsearch (6.8.2)
+      elasticsearch-api (= 6.8.2)
+      elasticsearch-transport (= 6.8.2)
+    elasticsearch-api (6.8.2)
       multi_json
     elasticsearch-dsl (0.1.9)
-    elasticsearch-model (7.1.1)
+    elasticsearch-model (6.1.1)
       activesupport (> 3)
-      elasticsearch (> 1)
+      elasticsearch (~> 6)
       hashie
-    elasticsearch-rails (7.1.1)
-    elasticsearch-transport (7.9.0)
+    elasticsearch-rails (6.1.1)
+    elasticsearch-transport (6.8.2)
       faraday (~> 1)
       multi_json
     equalizer (0.0.11)
@@ -470,10 +470,10 @@ DEPENDENCIES
   cloudinary
   commonmarker
   dotenv-rails
-  elasticsearch (~> 7.0)
+  elasticsearch (~> 6.8)
   elasticsearch-dsl
-  elasticsearch-model (~> 7.0)
-  elasticsearch-rails (~> 7.0)
+  elasticsearch-model (~> 6.1)
+  elasticsearch-rails (~> 6.1)
   factory_bot_rails
   faker
   font-awesome-sass


### PR DESCRIPTION
Reverts sankichi92/LiveLog#1008

`Faraday::ConnectionFailed: execution expired` で index が作成できず断念。
https://sentry.io/organizations/livelog/issues/1878887822/
