### PR TITLE
Setup documents for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# LiveLog AGENTS.md
+
+このファイルは、Codex を含むコーディング AI エージェント向けの最小ガイドです。  
+詳細は `docs/project-map.md` と `docs/infrastructure-inventory.md` を参照してください。
+
+## 目的
+
+- このリポジトリで安全かつ一貫した変更を行う。
+- 変更前に対象範囲と依存を把握し、不要な副作用を避ける。
+- 本番環境や外部サービスの変更は、必ず人手承認を得る。
+
+## 最初の 10 分
+
+1. セットアップ: `bin/setup --skip-server`
+2. 開発サーバー起動: `bin/dev`
+3. Ruby テスト: `bin/rails spec`
+4. Ruby Lint: `bin/rubocop`
+5. JavaScript/TypeScript Lint: `yarn run lint`
+
+## 必須チェック（変更内容に応じて実行）
+
+- Ruby コードを変更したら: `bin/rails spec` と `bin/rubocop`
+- JavaScript/TypeScript を変更したら: `yarn run lint`
+- DB スキーマ（`db/schemas/*.rb`）を変更したら:
+  - `bin/rails ridgepole:dry-run`
+  - `bin/rails ridgepole:apply`
+  - その後にテストを再実行
+
+## ガードレール
+
+- 本番環境や外部サービスの変更操作は、提案までに留める。実行前に必ず人手承認を得る。
+- 外部副作用のあるタスク（例: `tweet:*`, `mail:*`）は明示的な指示がある場合のみ実行する。
+- 既存の設計や運用前提を崩す変更をする場合は、変更理由と影響範囲を記録する。
+
+## 詳細資料
+
+- プロジェクト構造と変更影響: `docs/project-map.md`
+- インフラ依存の棚卸し: `docs/infrastructure-inventory.md`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Then, you can log in by email `admin@example.com` and password `password`.
 1. Sign up for [Cloudinary](https://cloudinary.com/)
 2. Overwrite `CLOUDINARY_URL` value in `.env`
 
+## AI Agent Docs
+
+- Entry point: `AGENTS.md`
+- Project map: `docs/project-map.md`
+- Infrastructure inventory: `docs/infrastructure-inventory.md`
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/sankichi92/LiveLog. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/sankichi92/LiveLog/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/infrastructure-inventory.md
+++ b/docs/infrastructure-inventory.md
@@ -1,0 +1,109 @@
+# インフラ依存棚卸し（AI エージェント向け）
+
+このドキュメントは、LiveLog の外部依存をコードベース起点で整理した棚卸しです。  
+目的は「現状の把握」であり、移行先比較や移行実装は本スコープ外です。
+
+## 1. 前提
+
+- 現在は Heroku 時代の構成に依存する箇所がある。
+- 将来的な移植・非依存化に備えて、まず依存の結合点を明確化する。
+- 本番環境および外部サービスへの変更は、常に人手承認を必須とする。
+
+## 2. 依存サービス一覧（現状）
+
+1. PostgreSQL
+- 用途: 主データストア
+- 結合点: `config/database.yml`, `db/Schemafile`, `db/schemas/*.rb`
+- 備考: スキーマ管理は Ridgepole
+
+2. Elasticsearch
+- 用途: 楽曲検索インデックス
+- 結合点: `config/initializers/elasticsearch.rb`, `lib/tasks/elasticsearch.rake`, `app/models/concerns/song_searchable.rb`
+- 関連環境変数: `ELASTICSEARCH_URL`, `ELASTICSEARCH_DEFAULT_ANALYZER_TYPE`
+
+3. MemCachier（Memcached）
+- 用途: 本番キャッシュストア
+- 結合点: `config/environments/production.rb`
+- 関連環境変数: `MEMCACHIER_SERVERS`, `MEMCACHIER_USERNAME`, `MEMCACHIER_PASSWORD`
+
+4. SendGrid（SMTP）
+- 用途: メール送信
+- 結合点: `config/environments/production.rb`
+- 関連環境変数: `SENDGRID_API_KEY`
+
+5. AWS S3（Active Storage）
+- 用途: ファイルストレージ
+- 結合点: `config/storage.yml`, `config/environments/production.rb`
+- 関連環境変数: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+
+6. Cloudinary
+- 用途: アバター画像アップロード/配信
+- 結合点: `app/models/avatar.rb`, `config/environments/production.rb`
+- 関連環境変数: `CLOUDINARY_URL`
+
+7. Auth0
+- 用途: ログイン/OAuth 連携
+- 結合点: `config/initializers/auth0.rb`, `config/initializers/omniauth.rb`, `app/controllers/auth_controller.rb`
+- 関連環境変数: `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_DOMAIN`, `AUTH0_API_AUDIENCE`, `AUTH0_RESOURCE_SERVER_ID`
+
+8. GitHub OAuth
+- 用途: Developer 連携
+- 結合点: `config/initializers/omniauth.rb`, `app/controllers/auth_controller.rb`
+- 関連環境変数: `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
+
+9. Slack
+- 用途: 通知・招待リンク
+- 結合点: `config/initializers/slack.rb`, `app/jobs/*_activity_notify_job.rb`, `config/routes.rb`
+- 関連環境変数: `SLACK_API_TOKEN`, `SLACK_NOTIFICATION_CHANNEL`, `SLACK_INVITATION_TOKEN`
+
+10. Twitter(X) API
+- 用途: 投稿タスク
+- 結合点: `config/initializers/twitter_client.rb`, `lib/twitter_client.rb`, `lib/tasks/tweet.rake`
+- 関連環境変数: `TWITTER_CONSUMER_KEY`, `TWITTER_CONSUMER_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET`
+
+11. Sentry
+- 用途: エラー監視
+- 結合点: `config/initializers/sentry.rb`, `app/controllers/concerns/sentry_user.rb`, `app/javascript/application.ts`, `app/javascript/admin.ts`
+- 関連環境変数: DSN は運用環境側設定に依存
+
+12. Scout APM / Barnes（Heroku 運用由来）
+- 用途: APM / ランタイム計測
+- 結合点: `Gemfile`, `config/puma.rb`
+- 備考: 利用実態は要確認
+
+## 3. 補助的な環境変数
+
+- `POSTGRES_HOST`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `LIVELOG_DATABASE_PASSWORD`
+- `RAILS_MAX_THREADS`, `RAILS_LOG_LEVEL`, `PORT`, `PIDFILE`
+- `SELENIUM_REMOTE`（system spec 実行時）
+
+## 4. ローカル/テストでの代替挙動
+
+- 開発:
+  - `config/environments/development.rb` で `cache_store = :memory_store`
+  - Active Storage は `local`
+- テスト:
+  - `config/environments/test.rb` で Active Storage は `test`
+  - Cloudinary はテスト用固定設定
+- Dev Container:
+  - PostgreSQL / Elasticsearch / Selenium を同梱（`.devcontainer/compose.yaml`）
+
+## 5. 副作用タスク（実行注意）
+
+- `bin/rails tweet:pickup_song`: 外部投稿の副作用あり
+- `bin/rails mail:pickup_song`: 外部送信の副作用あり
+- `bin/rails elasticsearch:import:song FORCE=y`: インデックス再構築
+
+これらは、明示指示がある場合のみ実行する。特に本番向けは人手承認を必須とする。
+
+## 6. 移植準備のための観点（比較はしない）
+
+- 外部サービス依存の接続設定を「初期化子・設定ファイル」に集約維持する。
+- モデル/ジョブから直接外部 API を叩く箇所は、抽象化レイヤ導入候補として識別する。
+- まずは依存の可視化と変更影響の縮小を優先し、移行先の選定は別フェーズで実施する。
+
+## 7. 関連資料
+
+- 入口ガイド: `AGENTS.md`
+- 構造マップ: `docs/project-map.md`
+

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -1,0 +1,85 @@
+# プロジェクトマップ（AI エージェント向け）
+
+このドキュメントは、LiveLog のコード構造・主要ドメイン・変更影響の見方をまとめたものです。  
+実装方針の細部に入る前に、まずここを読んで変更範囲を特定してください。
+
+## 1. アプリ概要
+
+- 種別: Ruby on Rails アプリケーション（Rails 8 / Ruby 3.4）
+- 主要機能: 軽音サークルのセットリスト管理
+- インターフェース:
+  - Web（公開画面）
+  - Web（管理画面 `/admin`）
+  - GraphQL API（`/api/graphql`）
+
+## 2. ディレクトリの見取り図
+
+- `app/`
+  - `models/`: ドメインロジック
+  - `controllers/`: Web/API エンドポイント
+  - `graphql/`: GraphQL スキーマ・型・クエリ
+  - `views/`: Haml テンプレート
+  - `javascript/`: フロントエンド（esbuild + TypeScript + Stimulus）
+  - `jobs/`: 通知や外部連携のジョブ
+- `config/`
+  - `routes.rb`: ルーティング全体
+  - `environments/*.rb`: 環境ごとの挙動
+  - `initializers/*.rb`: 外部サービス接続設定
+- `db/`
+  - `Schemafile`: Ridgepole の入口
+  - `schemas/*.rb`: 実スキーマ定義
+- `spec/`: RSpec（request/model/system/graphql/mailer）
+- `.devcontainer/`: 開発コンテナ設定（PostgreSQL/Elasticsearch/Selenium を含む）
+
+## 3. 主要ドメイン
+
+- `Live`: 開催ライブ
+- `Song`: ライブ内の楽曲
+- `Member`: メンバー
+- `Play`: メンバーと楽曲の演奏関係
+- `Entry` / `PlayableTime`: 出演エントリーと希望時間帯
+- `EntryGuideline`: 各ライブの募集要項
+- `User` / `Administrator` / `Developer`: 権限・ログイン関連
+- `Client`: OAuth クライアント情報
+
+## 4. ルーティング境界
+
+- 公開画面:
+  - `songs`, `lives`, `members`, `entries`, `summaries` など
+- 管理画面:
+  - `admin/lives`, `admin/members`, `admin/entries` など
+- API:
+  - `POST /api/graphql`
+  - `GET /api/scopes`
+
+詳細は `config/routes.rb` を一次情報として確認してください。
+
+## 5. 変更影響の見方
+
+- モデル変更: バリデーション/関連/スコープに合わせて model・request・system spec を確認
+- コントローラ変更: 対応する request spec を確認
+- GraphQL 変更: `app/graphql` と `spec/graphql/queries/*` を確認
+- JavaScript 変更: `app/javascript` と画面テンプレートの連携を確認
+- DB 変更: `db/schemas/*.rb` と関連 model/spec を確認
+
+## 6. 推奨検証フロー
+
+1. 依存セットアップ: `bin/setup --skip-server`
+2. Ruby Lint: `bin/rubocop`
+3. JavaScript/TypeScript Lint: `yarn run lint`
+4. テスト: `bin/rails spec`
+5. DB スキーマ変更時:
+   - `bin/rails ridgepole:dry-run`
+   - `bin/rails ridgepole:apply`
+   - `bin/rails spec` を再実行
+
+## 7. 作業時の運用ルール
+
+- 本番環境・外部サービスへの変更は、必ず人手承認を得る。
+- 外部副作用のあるタスク（通知・投稿・送信系）は、明示指示なしに実行しない。
+- 大きな変更では、影響範囲とロールバック可能性を先に整理する。
+
+## 8. 関連資料
+
+- 入口ガイド: `AGENTS.md`
+- インフラ依存の棚卸し: `docs/infrastructure-inventory.md`


### PR DESCRIPTION
## 概要
- AGENTS.md を新規追加し、Codex を含む AI エージェント向けの短い入口ガイドを整備
- docs/project-map.md を新規追加し、アプリ構造・主要ドメイン・変更影響・検証フローを明文化
- docs/infrastructure-inventory.md を新規追加し、Heroku 時代依存を含む外部サービス依存を棚卸し
- README.md に AI エージェント向け導線を最小追記
- 開発時の RuboCop コマンド表記を bin/rubocop -f github から bin/rubocop に修正

## 背景・経緯
- LiveLog は 2015 年に京大アンプラグドのセットリスト管理用途で開発され、2019 年頃以降は開発頻度が下がっていた
- インフラは Heroku と Add-on を前提に組まれており、将来的に移植や構成見直しが必要になる可能性がある
- ただし現時点では移行実装を急がず、まず AI エージェントが安全にリファクタ・改善を進められる土台として、現状把握と作業ガードレールを文書化することを優先した

## スコープ
- コード・API・DB スキーマには変更なし（ドキュメント整備のみ）
- 移行先比較や移行実装は今回のスコープ外

## 備考
- この PR は Codex が @sankichi92 の依頼に基づいて代理作成しました。
