### PR TITLE
Configure Renovate Ruby version synchronization

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>sankichi92/renovate-config"],
-  "packageRules": [{ "matchPackageNames": ["ruby"], "groupName": "ruby" }]
+  "packageRules": [
+    {
+      "matchPackageNames": ["ruby"],
+      "matchDatasources": ["ruby-version"],
+      "groupName": "ruby",
+      "postUpgradeTasks": {
+        "commands": ["bundle update --bundler --ruby"],
+        "fileFilters": ["Gemfile.lock"],
+        "executionMode": "branch"
+      },
+      "bumpVersions": [
+        {
+          "name": "Sync Ruby version in Gemfile",
+          "filePatterns": ["Gemfile"],
+          "matchStrings": ["ruby ['\"](?<version>\\d+\\.\\d+\\.\\d+)['\"]"],
+          "bumpType": "sync"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## 背景

Ruby のパッチバージョン更新で `.ruby-version` だけが更新され、`Gemfile` と `Gemfile.lock` の Ruby version が古いまま残ると、Bundler の version mismatch で CI が落ちる。

## 変更内容

Ruby 本体の Renovate 更新に限定して、`Gemfile` の Ruby version を同期する `bumpVersions` を追加した。

`Gemfile` 更新後に `bundle update --bundler --ruby` を実行する `postUpgradeTasks` を追加し、`Gemfile.lock` は Bundler に更新させる。

## 確認

- `jq . renovate.json`
- `git diff --check -- renovate.json`
- `renovate-config-validator`

`postUpgradeTasks` は Mend hosted Renovate 側の `allowedCommands` に依存するため、実行可否は Renovate の実行ログで確認する。
