### PR TITLE
Configure Renovate to sync Ruby lockfile metadata

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,16 +6,17 @@
       "matchPackageNames": ["ruby"],
       "matchDatasources": ["ruby-version"],
       "groupName": "ruby",
-      "postUpgradeTasks": {
-        "commands": ["bundle update --bundler --ruby"],
-        "fileFilters": ["Gemfile.lock"],
-        "executionMode": "branch"
-      },
       "bumpVersions": [
         {
           "name": "Sync Ruby version in Gemfile",
           "filePatterns": ["Gemfile"],
           "matchStrings": ["ruby ['\"](?<version>\\d+\\.\\d+\\.\\d+)['\"]"],
+          "bumpType": "sync"
+        },
+        {
+          "name": "Sync Ruby version in Gemfile.lock",
+          "filePatterns": ["Gemfile.lock"],
+          "matchStrings": ["ruby (?<version>\\d+\\.\\d+\\.\\d+)"],
           "bumpType": "sync"
         }
       ]


### PR DESCRIPTION
## 背景

Ruby 4.0.3 へのパッチアップデートで `postUpgradeTasks` の `bundle update --bundler --ruby` が Mend hosted Renovate の `allowedCommands` に許可されず、`Gemfile.lock` の `RUBY VERSION` が更新されなかった。

その結果、Ruby CI の `ruby/setup-ruby` が Bundler の frozen mode で停止していた。

## 変更内容

Ruby 本体の Renovate 更新では、`postUpgradeTasks` を使わず `bumpVersions` で `Gemfile` と `Gemfile.lock` の Ruby version を同期する。

`Gemfile.lock` の Bundler version は自動更新対象から外す。Bundler 本体の更新は別途 Bundler 更新として扱う。

## 確認

- `jq . renovate.json`
- `git diff --check -- renovate.json`
- `renovate-config-validator`
