### PR TITLE
Stabilize play form Select2 initialization

### DIFF
--- a/app/javascript/controllers/admin/form_plays_controller.js
+++ b/app/javascript/controllers/admin/form_plays_controller.js
@@ -23,6 +23,6 @@ export default class extends Controller {
   }
 
   _initializeSelect2() {
-    $('.member-select').select2({ theme: 'bootstrap4', width: '100%' });
+    $('.member-select:not(.select2-hidden-accessible)').select2({ theme: 'bootstrap4', width: '100%' });
   }
 }

--- a/app/javascript/controllers/form_plays_controller.js
+++ b/app/javascript/controllers/form_plays_controller.js
@@ -23,6 +23,6 @@ export default class extends Controller {
   }
 
   _initializeSelect2() {
-    $('.member-select').select2({ theme: 'bootstrap4', width: '100%' });
+    $('.member-select:not(.select2-hidden-accessible)').select2({ theme: 'bootstrap4', width: '100%' });
   }
 }

--- a/spec/system/admin/song_system_spec.rb
+++ b/spec/system/admin/song_system_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe 'Admin song system:' do
     expect(page).to have_css '.play-form', count: 3
 
     # When
-    click_on '削除', match: :first
+    within first('.play-form-visible-fields') do
+      click_on '削除'
+    end
 
     # Then
     expect(page).to have_css '.play-form', count: 3
@@ -68,7 +70,9 @@ RSpec.describe 'Admin song system:' do
 
     # When
     fill_in '曲名', with: 'after'
-    click_on '削除', match: :first
+    within first('.play-form-visible-fields') do
+      click_on '削除'
+    end
     click_on '更新する'
 
     # Then


### PR DESCRIPTION
## 概要

フォーム上の演者セレクトに対する Select2 初期化を未初期化の select だけに限定し、system spec の削除操作を表示中の play form にスコープしました。

## 背景

`Admin song system` が GitHub Actions 上で、DOM 更新中の要素に対する Selenium の可視判定で失敗していました。演者フォームの `<template>` 内にも `削除` ボタンがあるため、`click_on '削除'` がテンプレート内の要素も含めて可視判定する余地がありました。

あわせて、演者フォームを追加するたびに既存の Select2 も再初期化していたため、未初期化の select だけを対象にして DOM の揺れを減らしています。

## 確認

- `USE_DOCKER_SELENIUM=1 bundle exec rspec spec/system/admin/song_system_spec.rb:6 --seed 15734` を3回連続で成功
- `USE_DOCKER_SELENIUM=1 bundle exec rspec spec/system/admin/song_system_spec.rb --seed 15734`
- `USE_DOCKER_SELENIUM=1 bundle exec rspec --seed 15734`
- `yarn prettier app/javascript/controllers/admin/form_plays_controller.js app/javascript/controllers/form_plays_controller.js --check`
- `yarn tsc`
- `git diff --check`

rebase 後の `main` は Ruby 4.0.4 指定ですが、手元には Ruby 4.0.4 が入っていないため、追加修正後の RSpec は CI で確認します。`yarn run lint` は変更外の `.claude/settings.local.json` の Prettier 警告で停止しました。
